### PR TITLE
Fixed bug with starting raft node

### DIFF
--- a/joinRaftNetwork.js
+++ b/joinRaftNetwork.js
@@ -21,6 +21,7 @@ function displayGethAccount(result, cb){
 function startRaftNode(result, cb){
   let options = {encoding: 'utf8', timeout: 100*1000}
   let cmd = './startRaftNode.sh'
+  cmd += ' '+setup.targetGasLimit
   cmd += ' '+ports.gethNode
   cmd += ' '+ports.gethNodeRPC
   cmd += ' '+ports.gethNodeWS_RPC


### PR DESCRIPTION
On joining a raft network as a non-cordinator node, I get the following error on screen
"
ERROR: ./startRaftNode.sh: line 19: $6: unbound variable

ERROR ./startRaftNode.sh: line 19: $6: unbound variable
"
I fixed this by passing the targetGasLimit. 